### PR TITLE
2 stage build Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 GOBASE=$(shell pwd)
 GOBIN=$(GOBASE)/bin
+BUILD_DIR=build
+EXECUTABLE=taraxa-indexer
+
 
 help:
 	@echo "This is a helper makefile for taraxa-indexer"
@@ -22,3 +25,10 @@ generate:
 tidy:
 	@echo "tidy..."
 	go mod tidy
+
+build: clean
+	@mkdir -p $(BUILD_DIR)/linux_amd64
+	env GOOS=linux GOARCH=amd64 go build -o $(BUILD_DIR)/linux_amd64/ ./...
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,12 @@ GOBIN=$(GOBASE)/bin
 BUILD_DIR=build
 EXECUTABLE=taraxa-indexer
 
-
 help:
 	@echo "This is a helper makefile for taraxa-indexer"
 	@echo "Targets:"
 	@echo "    generate:    regenerate all api generated files"
 	@echo "    tidy         tidy go mod"
+	@echo "    make         builds executable"
 
 $(GOBIN)/golangci-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v1.51.1
@@ -28,7 +28,7 @@ tidy:
 
 build: clean
 	@mkdir -p $(BUILD_DIR)/linux_amd64
-	env GOOS=linux GOARCH=amd64 go build -o $(BUILD_DIR)/linux_amd64/ ./...
+	env GOOS=linux GOARCH=amd64 go build -o $(BUILD_DIR)/linux_amd64/$(EXECUTABLE)
 
 clean:
 	rm -rf $(BUILD_DIR)


### PR DESCRIPTION
Builds inside of `Dockerfile` were not working becasue only all Go sources were copied into image.


Commits:
- added more targets to Makefile
- 2 stage build docker


Executable image inside which we run `taraxa-indexer` executable is based tiny image https://hub.docker.com/_/scratch/


